### PR TITLE
add .gitattributes, vendor HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+test/report.html linguist-vendored
+test/mysql-aqua.html linguist-vendored
+missing-doc.html linguist-vendored


### PR DESCRIPTION
Hello,

My heart bleeds when I see a nice Common Lisp repository labelled as HTML code, as it happens here because of 3 large HTML files in the test directory.

We can hide them for the repository's language stats. Therefore GitHub's banner will say this repo is 78.6% CL. It's more accurate, and pushes CL a bit more under the light ;)

https://github.com/github/linguist/#overrides