### PR TITLE
Fix release build: require ASDF in Makefile, fail-fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,20 @@
 all: rlgl
 
-SBCL_REGISTRY := --eval "(asdf:initialize-source-registry \`(:source-registry :inherit-configuration (:tree ,(uiop:getcwd))))"
+# Load ASDF explicitly (not all SBCL builds preload it) before configuring
+# the source registry to include the project tree and its vendored ocicl/.
+SBCL_INIT := --eval "(require :asdf)" \
+             --eval "(asdf:initialize-source-registry \`(:source-registry :inherit-configuration (:tree ,(uiop:getcwd))))"
 
-# Build the standalone rlgl binary.
+# Build the standalone rlgl binary.  --non-interactive makes a build error
+# exit non-zero instead of dropping into the debugger and reporting success.
 rlgl: *.lisp */*.lisp *.asd
-	sbcl $(SBCL_REGISTRY) --eval "(asdf:make :rlgl)" --eval "(quit)"
+	sbcl --non-interactive $(SBCL_INIT) --eval "(asdf:make :rlgl)"
 
 # Run the test suite against the engine (no server required).
 check:
 	sbcl --dynamic-space-size 4096 \
 	     --disable-debugger \
-	     $(SBCL_REGISTRY) \
+	     $(SBCL_INIT) \
 	     --eval '(asdf:load-system :prove)' \
 	     --eval '(asdf:load-system :rlgl)' \
 	     --eval '(asdf:load-system :test-rlgl)' \


### PR DESCRIPTION
The `v2.0.0` release run failed: every build job produced no binary and then failed at the packaging step with `cp: cannot stat 'rlgl'`. Root cause: the release jobs install SBCL (apt/brew/dnf) **without** an ocicl-generated `~/.sbclrc`, so ASDF wasn't preloaded and the Makefile's `(asdf:initialize-source-registry ...)` hit `SB-INT:SIMPLE-READER-PACKAGE-ERROR: Package ASDF does not exist`. The `rlgl` target also lacked `--non-interactive`, so SBCL dropped into the (EOF) debugger and exited 0 — masking the failure.

`build.yml` passed only because `ocicl setup >> ~/.sbclrc` had loaded ASDF there.

Fix: add `(require :asdf)` before using `asdf:` in both the `rlgl` and `check` targets, and build with `--non-interactive` so a build error fails the step loudly. (This matches icl's Makefile, which starts with `(require 'asdf)`.)

Verified locally with `sbcl --no-userinit --no-sysinit` (simulating a runner with no ocicl sbclrc): the binary builds and reports version 2.0.0.

Once merged, the `v2.0.0` tag will be re-pointed to retrigger the release (the prior run published no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)