### PR TITLE
Use OS-native git paths so policy ops work on Windows (v2.0.2)

### DIFF
--- a/policy.lisp
+++ b/policy.lisp
@@ -30,13 +30,16 @@
 (defun git (directory &rest args)
   "Run git with ARGS inside DIRECTORY (via -C; pass NIL for no directory) and
 return its standard output as a string.  Invokes git directly (no shell), so
-it is portable across platforms.  Signals on non-zero exit."
+it is portable across platforms.  DIRECTORY is passed to git as an OS-native
+path so it resolves correctly on Windows (drive letter, backslashes).  git's
+stderr is left attached so any failure is visible in the log.  Signals on
+non-zero exit."
   (uiop:run-program
    (list* "git"
-          (append (when directory (list "-C" (namestring directory)))
+          (append (when directory (list "-C" (uiop:native-namestring directory)))
                   args))
    :output :string
-   :error-output :output
+   :error-output t
    :ignore-error-status nil))
 
 (defun git-lines (directory &rest args)

--- a/releng/debian/changelog
+++ b/releng/debian/changelog
@@ -1,3 +1,10 @@
+rlgl (2.0.2-1) unstable; urgency=medium
+
+  * Use OS-native paths when invoking git so policy clone/blame work on
+    Windows.
+
+ -- Anthony Green <green@moxielogic.com>  Thu, 18 Jun 2026 18:00:00 -0500
+
 rlgl (2.0.1-1) unstable; urgency=medium
 
   * Built-in (pure-Lisp) report recognition; portable git invocation; no

--- a/releng/rlgl.spec
+++ b/releng/rlgl.spec
@@ -1,5 +1,5 @@
 Name:           rlgl
-Version:        2.0.1
+Version:        2.0.2
 Release:        1%{?dist}
 Summary:        Git-centric policy management and enforcement tool
 
@@ -55,6 +55,8 @@ fi
 %{_datadir}/sbom/rlgl-%{version}.spdx.json
 
 %changelog
+* Thu Jun 18 2026 Anthony Green <green@moxielogic.com> - 2.0.2-1
+- Use OS-native paths when invoking git so policy clone/blame work on Windows
 * Thu Jun 18 2026 Anthony Green <green@moxielogic.com> - 2.0.1-1
 - Built-in (pure-Lisp) report recognition; portable git invocation; no
   external recog.d/shell/grep dependency

--- a/rlgl.asd
+++ b/rlgl.asd
@@ -19,7 +19,7 @@
 (asdf:defsystem #:rlgl
   :description "Red Light Green Light - a client-side policy enforcement tool."
   :author "Anthony Green <green@moxielogic.com>"
-  :version "2.0.1"
+  :version "2.0.2"
   :serial t
   :components ((:file "package")
                (:file "matcher")

--- a/rlgl.lisp
+++ b/rlgl.lisp
@@ -35,13 +35,20 @@
 ;; clone/pull into a local cache.
 
 (defun ensure-policy-dir ()
-  "Initialize POLICY:*POLICY-DIR* (where policy repos are cloned)."
-  (let ((dir (uiop:ensure-directory-pathname
-              (or (uiop:getenv "RLGL_POLICY_DIR")
-                  (merge-pathnames "rlgl/policies/"
-                                   (uiop:xdg-cache-home))))))
+  "Initialize POLICY:*POLICY-DIR* (where policy repos are cloned).  Resolve to
+an OS-native absolute path so git receives a drive-qualified directory on
+Windows (uiop:xdg-cache-home there yields a drive-less path that git
+misresolves).  LOCALAPPDATA is only set on Windows, so this is a no-op
+elsewhere."
+  (let* ((base (or (uiop:getenv "RLGL_POLICY_DIR")
+                   (let ((localappdata (uiop:getenv "LOCALAPPDATA")))
+                     (and localappdata
+                          (merge-pathnames "rlgl/policies/"
+                                           (uiop:ensure-directory-pathname localappdata))))
+                   (merge-pathnames "rlgl/policies/" (uiop:xdg-cache-home))))
+         (dir (uiop:ensure-directory-pathname base)))
     (ensure-directories-exist dir)
-    (setf policy:*policy-dir* (namestring dir))))
+    (setf policy:*policy-dir* (uiop:native-namestring dir))))
 
 ;; ----------------------------------------------------------------------------
 ;; Self-contained report assets.  The CSS (with the logo inlined as a


### PR DESCRIPTION
On Windows, `rlgl.exe` ran (after the libffi-side chmod fix) but failed evaluating: `git -C /Users/runneradmin/AppData/Local/cache/rlgl/policies/<h>/ blame -s -l XFAIL` exited 128. Two causes:

- `uiop:xdg-cache-home` returns a **drive-less** path on Windows (`/Users/...`, no `C:`), and Lisp namestrings use forward slashes — native `git.exe` misresolves these. Clone happened to land somewhere, but `-C` blame couldn't.

Fixes:
- `ensure-policy-dir` resolves the cache dir to an **OS-native absolute path**, basing it on `LOCALAPPDATA` on Windows (drive-qualified) and `xdg-cache-home` elsewhere.
- The `git` helper passes the `-C` directory through `uiop:native-namestring`.
- git's stderr is left attached so any future failure is visible in CI logs.

`make check` passes on Linux (no regression). Windows is validated by libffi CI, which tracks the latest release. Bumped to **2.0.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)