### PR TITLE
Preserve Windows drive letter for git -C paths (v2.0.3)

### DIFF
--- a/policy.lisp
+++ b/policy.lisp
@@ -79,7 +79,10 @@ based on URL."
   ;; Hold one big lock, just in case...
   (bt:with-lock-held (*policy-lock*)
 
-    (let* ((policy-dirname (str:concat (namestring *policy-dir*)
+    ;; *POLICY-DIR* is already an OS-native namestring; concatenate directly.
+    ;; (Round-tripping through NAMESTRING/DIRECTORY-NAMESTRING on Windows drops
+    ;; the drive letter, since the device is a separate pathname component.)
+    (let* ((policy-dirname (str:concat *policy-dir*
 				       (subseq (ironclad:byte-array-to-hex-string
 						(ironclad:digest-sequence
 						 :sha1 (flexi-streams:string-to-octets url)))
@@ -186,7 +189,8 @@ exists after the JSON object, or NIL otherwise."
 
 (defun read-json-patterns (kind filename)
   (let ((patterns (list)))
-    (let ((matcher-lines (git-lines (directory-namestring filename)
+    (let ((matcher-lines (git-lines (uiop:native-namestring
+				     (uiop:pathname-directory-pathname filename))
 				    "blame" "-s" "-l" (file-namestring filename))))
       (dolist (matcher-line matcher-lines)
 	;; For boundary (e.g. root) commits, git blame prefixes the line with
@@ -221,7 +225,8 @@ exists after the JSON object, or NIL otherwise."
 		     (not (string= githash ; check for local change
 				   "0000000000000000000000000000000000000000")))
 	    (progn
-	      (setf log-entry (git-lines (directory-namestring filename)
+	      (setf log-entry (git-lines (uiop:native-namestring
+					  (uiop:pathname-directory-pathname filename))
 					 "log" "-n" "1" "-r" githash
 					 (file-namestring filename)))
 	      (setf (gethash githash *git-log-table*) log-entry)))

--- a/releng/debian/changelog
+++ b/releng/debian/changelog
@@ -1,3 +1,9 @@
+rlgl (2.0.3-1) unstable; urgency=medium
+
+  * Preserve the Windows drive letter when deriving git -C paths.
+
+ -- Anthony Green <green@moxielogic.com>  Fri, 19 Jun 2026 09:00:00 -0500
+
 rlgl (2.0.2-1) unstable; urgency=medium
 
   * Use OS-native paths when invoking git so policy clone/blame work on

--- a/releng/rlgl.spec
+++ b/releng/rlgl.spec
@@ -1,5 +1,5 @@
 Name:           rlgl
-Version:        2.0.2
+Version:        2.0.3
 Release:        1%{?dist}
 Summary:        Git-centric policy management and enforcement tool
 
@@ -55,6 +55,9 @@ fi
 %{_datadir}/sbom/rlgl-%{version}.spdx.json
 
 %changelog
+* Fri Jun 19 2026 Anthony Green <green@moxielogic.com> - 2.0.3-1
+- Preserve the Windows drive letter when deriving git -C paths (use
+  native-namestring of the directory pathname, not directory-namestring)
 * Thu Jun 18 2026 Anthony Green <green@moxielogic.com> - 2.0.2-1
 - Use OS-native paths when invoking git so policy clone/blame work on Windows
 * Thu Jun 18 2026 Anthony Green <green@moxielogic.com> - 2.0.1-1

--- a/rlgl.asd
+++ b/rlgl.asd
@@ -19,7 +19,7 @@
 (asdf:defsystem #:rlgl
   :description "Red Light Green Light - a client-side policy enforcement tool."
   :author "Anthony Green <green@moxielogic.com>"
-  :version "2.0.2"
+  :version "2.0.3"
   :serial t
   :components ((:file "package")
                (:file "matcher")


### PR DESCRIPTION
On Windows, `git -C` got a drive-less path (`\Users\...` instead of `C:\Users\...`) and failed with exit 128, because `read-json-patterns` used `directory-namestring` (which excludes the pathname *device* per the CL spec). Use `uiop:native-namestring` of the directory pathname (device included) for the blame/log git calls, and stop re-`namestring`ing the already-native `*policy-dir*`. clone/rev-parse/log were already fine. `make check` passes on Linux; Windows validated via libffi CI. → v2.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)