### PR TITLE
Build Intel macOS binary via Rosetta (v2.0.4)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -443,10 +443,10 @@ jobs:
 
   build-macos-amd64:
     needs: [fetch-deps, extract-version]
-    runs-on: macos-13
-    # Intel macOS runners are scarce/being deprecated; never let this block
-    # the release.  Downstream jobs do not depend on it, and it is best-effort.
-    continue-on-error: true
+    # GitHub's free Intel (macos-13) runners never schedule for this repo, so
+    # build the x86_64 binary on an Apple-Silicon runner via Rosetta + an
+    # x86_64 Homebrew SBCL.
+    runs-on: macos-14
     env:
       VERSION: ${{ needs.extract-version.outputs.version }}
     steps:
@@ -462,15 +462,23 @@ jobs:
       - name: Remove .git to prevent dirty version detection
         run: rm -rf .git
 
-      - name: Install dependencies
-        run: brew install sbcl
-
-      - name: Build
-        run: make rlgl
-
-      - name: Verify version is not dirty
+      - name: Install Rosetta and x86_64 SBCL
         run: |
-          VERSION=$(./rlgl --version 2>&1 || true)
+          softwareupdate --install-rosetta --agree-to-license || true
+          if ! arch -x86_64 /usr/local/bin/brew --version >/dev/null 2>&1; then
+            arch -x86_64 /bin/bash -c 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+          fi
+          arch -x86_64 /usr/local/bin/brew install sbcl
+
+      - name: Build (x86_64 under Rosetta)
+        run: |
+          arch -x86_64 /bin/bash -c 'eval "$(/usr/local/bin/brew shellenv)"; sbcl --version; make rlgl'
+
+      - name: Verify architecture and version
+        run: |
+          file ./rlgl
+          file ./rlgl | grep -q x86_64 || { echo "::error::rlgl is not x86_64"; exit 1; }
+          VERSION=$(arch -x86_64 ./rlgl --version 2>&1 || true)
           echo "rlgl version: $VERSION"
           if echo "$VERSION" | grep -qi dirty; then
             echo "::error::Version string contains 'dirty': $VERSION"
@@ -493,7 +501,7 @@ jobs:
   # Sign release tarballs with Cosign
   # ========================================
   sign-artifacts:
-    needs: [build-linux-tarball, build-linux-arm64, build-macos-arm64, extract-version]
+    needs: [build-linux-tarball, build-linux-arm64, build-macos-arm64, build-macos-amd64, extract-version]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -546,7 +554,7 @@ jobs:
   # Generate SLSA Level 3 provenance
   # ========================================
   generate-provenance-subjects:
-    needs: [build-rpm, build-deb, build-linux-tarball, build-linux-arm64, build-windows, build-macos-arm64, extract-version]
+    needs: [build-rpm, build-deb, build-linux-tarball, build-linux-arm64, build-windows, build-macos-arm64, build-macos-amd64, extract-version]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -581,7 +589,7 @@ jobs:
   # Create GitHub Release
   # ========================================
   release:
-    needs: [build-rpm, build-deb, build-linux-tarball, build-linux-arm64, build-windows, build-macos-arm64, sign-artifacts, slsa-provenance, extract-version]
+    needs: [build-rpm, build-deb, build-linux-tarball, build-linux-arm64, build-windows, build-macos-arm64, build-macos-amd64, sign-artifacts, slsa-provenance, extract-version]
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/releng/debian/changelog
+++ b/releng/debian/changelog
@@ -1,3 +1,9 @@
+rlgl (2.0.4-1) unstable; urgency=medium
+
+  * Build the Intel (x86_64) macOS binary via Rosetta on an Apple-Silicon runner.
+
+ -- Anthony Green <green@moxielogic.com>  Fri, 19 Jun 2026 10:00:00 -0500
+
 rlgl (2.0.3-1) unstable; urgency=medium
 
   * Preserve the Windows drive letter when deriving git -C paths.

--- a/releng/rlgl.spec
+++ b/releng/rlgl.spec
@@ -1,5 +1,5 @@
 Name:           rlgl
-Version:        2.0.3
+Version:        2.0.4
 Release:        1%{?dist}
 Summary:        Git-centric policy management and enforcement tool
 
@@ -55,6 +55,8 @@ fi
 %{_datadir}/sbom/rlgl-%{version}.spdx.json
 
 %changelog
+* Fri Jun 19 2026 Anthony Green <green@moxielogic.com> - 2.0.4-1
+- Build the Intel (x86_64) macOS binary on an Apple-Silicon runner via Rosetta
 * Fri Jun 19 2026 Anthony Green <green@moxielogic.com> - 2.0.3-1
 - Preserve the Windows drive letter when deriving git -C paths (use
   native-namestring of the directory pathname, not directory-namestring)

--- a/rlgl.asd
+++ b/rlgl.asd
@@ -19,7 +19,7 @@
 (asdf:defsystem #:rlgl
   :description "Red Light Green Light - a client-side policy enforcement tool."
   :author "Anthony Green <green@moxielogic.com>"
-  :version "2.0.3"
+  :version "2.0.4"
   :serial t
   :components ((:file "package")
                (:file "matcher")


### PR DESCRIPTION
GitHub's free Intel `macos-13` runners never schedule for this repo (the darwin-amd64 build job queued 20+h), so no Intel macOS binary was ever published — only arm64. Build x86_64 on a `macos-14` (Apple-Silicon) runner under Rosetta with an x86_64 Homebrew SBCL, and restore it as a blocking job so the asset ships. → v2.0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)